### PR TITLE
add syslog servers per location v33+

### DIFF
--- a/dbsummary.py
+++ b/dbsummary.py
@@ -275,6 +275,10 @@ class DBAnalyser:
         platform_dnsservers = self._builddict_join(self.configuration, 'platform_systemlocation_dns_servers', 'systemlocation_id', 'dnsserver_id', 'platform_dnsserver', 'address')
         platform_ntpservers = self._builddict_join(self.configuration, 'platform_systemlocation_ntp_servers', 'systemlocation_id', 'ntpserver_id', 'platform_ntpserver', 'address')
         platform_client_stunservers = self._builddict_join(self.configuration, 'platform_systemlocation_client_stun_servers', 'systemlocation_id', 'stunserver_id', 'platform_stunserver', 'address')
+        if int(self.version['version-id'].split('.', 1)[0]) >= 33:
+            platform_syslogservers = self._builddict_join(self.configuration, 'platform_systemlocation_syslog_servers', 'systemlocation_id', 'syslogserver_id', 'platform_syslogserver', 'address')
+        else:
+            platform_syslogservers = {}
         if int(self.version['version-id'].split('.', 1)[0]) >= 29:
             platform_client_turnservers = self._builddict_join(self.configuration, 'platform_systemlocation_client_turn_servers', 'systemlocation_id', 'turnserver_id', 'platform_turnserver', 'address')
         else:
@@ -372,6 +376,10 @@ class DBAnalyser:
 
             if loc['mtu']:
                 print("MTU: %s" % (loc['mtu'],))
+
+            if location_id in platform_syslogservers:
+                print("Syslog Servers: %s" % ', '.join(platform_syslogservers[location_id]))
+                blob[loc['name']]['syslog_servers'] = platform_syslogservers[location_id]
 
             if loc['local_mssip_domain']:
                 self._do_mssipdomain(loc['local_mssip_domain'])


### PR DESCRIPTION
amends the location configuration with the below example from v33 onwards

```
Reading SBC
===========
DNS: 1.1.1.1, 8.8.8.8
NTP: 0.pexip.pool.ntp.org, 1.pexip.pool.ntp.org, 2.pexip.pool.ntp.org
MTU: 1390
Syslog Servers: 1.1.1.1
Transcoding Location: Reading Transcoding
Overflow: Cloud Bursting


Reading Transcoding
===================
DNS: 10.44.0.15, 10.44.0.25
NTP: 0.pexip.pool.ntp.org, 1.pexip.pool.ntp.org, 2.pexip.pool.ntp.org
MTU: 1390
Syslog Servers: 1.1.1.1, 1.1.1.2
```