### PR TITLE
remove unused import and switch from pyOpenSSL to cryptography

### DIFF
--- a/dbsummary.py
+++ b/dbsummary.py
@@ -21,7 +21,6 @@ import operator
 import os
 import re
 import sqlite3
-import socket
 import sys
 from datetime import datetime, timedelta
 
@@ -38,7 +37,7 @@ except Exception:
     pass
 
 try:
-    from OpenSSL import crypto
+    from cryptography import x509
     do_ssl = True
 except ImportError:
     do_ssl = False
@@ -969,15 +968,14 @@ class DBAnalyser:
 
         for cacert in cacerts:
             try:
-                cert = crypto.load_certificate(crypto.FILETYPE_PEM, cacert)
-            except (IOError, crypto.Error):
+                cert = x509.load_pem_x509_certificate(cacert.encode())
+            except ValueError:
                 continue
 
-            cn = dict(cert.get_subject().get_components()).get(b'CN', b"").decode()
-            data = {'CN': cn,
-                    'Issuer': dict(cert.get_issuer().get_components()).get(b'CN', b"").decode(),
-                    'Expiry': datetime.strptime(cert.get_notAfter().decode(), "%Y%m%d%H%M%SZ")}
-            intermediates[cn] = data
+            data = {'CN': cert.subject.rfc4514_string(),
+                    'Issuer': cert.issuer.rfc4514_string(),
+                    'Expiry': cert.not_valid_after_utc,}
+            intermediates[cert.subject.rfc4514_string()] = data
 
 
         def validate_issuer(issuer):
@@ -1005,28 +1003,28 @@ class DBAnalyser:
                 continue
 
             try:
-                cert = crypto.load_certificate(crypto.FILETYPE_PEM, platform_tlscertificate[cert_id]['certificate'])
-            except (IOError, crypto.Error):
+                cert = x509.load_pem_x509_certificate(platform_tlscertificate[cert_id]['certificate'].encode())
+            except ValueError:
                 continue
 
             fqdn = ', '.join(tlscerts[cert_id])
-            sn = cert.get_serial_number()
-            issuer = dict(cert.get_issuer().get_components()).get(b'CN', b"").decode()
-            data = {'CN': dict(cert.get_subject().get_components()).get(b'CN', b"").decode(),
+            sn = cert.serial_number
+            issuer = cert.issuer.rfc4514_string()
+            data = {'CN': cert.subject.rfc4514_string(),
                     'Issuer': issuer,
                     'Chain': validate_issuer(issuer),
-                    'Expiry': datetime.strptime(cert.get_notAfter().decode(), "%Y%m%d%H%M%SZ"),
-                    'Signature': cert.get_signature_algorithm(),
+                    'Expiry': cert.not_valid_after_utc,
+                    'Signature': cert.signature_algorithm_oid._name.encode(),
                     'Hosts': [fqdn] }
 
             san = None
-            for i in range(cert.get_extension_count()):
-                if cert.get_extension(i).get_short_name() == b'subjectAltName':
-                    san = cert.get_extension(i)
+            for ext in cert.extensions:
+                if ext.oid == x509.ExtensionOID.SUBJECT_ALTERNATIVE_NAME:
+                    san = ext.value.get_values_for_type(x509.DNSName)
                     break
 
             if san:
-                data['SANs'] = str(san)
+                data['SANs'] = ', '.join(f'DNS:{san}' for san in san)
 
             if sn in certs:
                 certs[sn]['Hosts'].append(fqdn)


### PR DESCRIPTION
Switch to cryptography due to the below;

```
/Users/d/pexscripts/dbsummary.py:1024: DeprecationWarning: This API is deprecated and will be removed in a future version of pyOpenSSL. You should use pyca/cryptography's X.509 APIs instead.
  if cert.get_extension(i).get_short_name() == b'subjectAltName':
/Users/d/pexscripts/dbsummary.py:1025: DeprecationWarning: This API is deprecated and will be removed in a future version of pyOpenSSL. You should use pyca/cryptography's X.509 APIs instead.
  san = cert.get_extension(i)
```

and maintain the format

```
TLS Certificates
================
CN=zmgr.darren.gdn
 -> Issuer: CN=R10,O=Let's Encrypt,C=US (Validates: True)
    Expiry: 2025-08-18 03:52:56+00:00
 Signature: sha256WithRSAEncryption
      SANs: DNS:z.darren.gdn, DNS:zedge.darren.gdn, DNS:zmgr.darren.gdn, DNS:zworker.darren.gdn
 => zworker.darren.gdn
```

Requires the following

```
pip install cryptography
```