### PR TITLE
also check for tls_client_certificate_id when outputting tls certs

### DIFF
--- a/dbsummary.py
+++ b/dbsummary.py
@@ -1012,7 +1012,7 @@ class DBAnalyser:
         print("Total VMRs configured  : %d" % (vmr_count,))
 
     def tls_certs(self):
-        platform_workervm = self._builddict(self.configuration, 'platform_workervm', ('name', 'hostname', 'domain', 'address', 'alternative_fqdn', 'tls_certificate_id'), 'id')
+        platform_workervm = self._builddict(self.configuration, 'platform_workervm', ('name', 'hostname', 'domain', 'address', 'alternative_fqdn', 'tls_certificate_id', 'tls_client_certificate_id'), 'id')
         platform_tlscertificate = self._builddict(self.configuration, 'platform_tlscertificate', ('certificate',), 'id')
         platform_trustedca = self._builddict(self.configuration, 'platform_trustedca', ('certificate',), 'id')
 
@@ -1065,6 +1065,8 @@ class DBAnalyser:
                 fqdn += ' [%s]' % worker['alternative_fqdn']
             if worker['tls_certificate_id'] in tlscerts:
                 tlscerts[worker['tls_certificate_id']].append(fqdn)
+            if worker['tls_client_certificate_id'] in tlscerts:
+                tlscerts[worker['tls_client_certificate_id']].append(fqdn)
 
         for cert_id in tlscerts.keys():
             if len(tlscerts[cert_id]) == 0:


### PR DESCRIPTION
Adds output for client tls certs assigned to a node 

```
TLS Certificates
================
CN=*.pexipdemo.com
 -> Issuer: CN=R12,O=Let's Encrypt,C=US (Validates: True)
    Expiry: 2026-07-02 09:08:38+00:00
 Signature: sha256WithRSAEncryption
      SANs: DNS:*.pexipdemo.com, DNS:pexipdemo.com
       EKU: serverAuth
 => aus-cn1.pexipdemo.com [aus-cn1.pexipdemo.com], no-cn1.pexipdemo.com [no-cn1.pexipdemo.com], no-cn2.pexipdemo.com [no-cn2.pexipdemo.com], no-cn3.pexipdemo.com [no-cn3.pexipdemo.com], no-cn4.pexipdemo.com [no-cn4.pexipdemo.com], no-cn5.pexipdemo.com [no-cn5.pexipdemo.com], no-cn6.pexipdemo.com [no-cn6.pexipdemo.com], sin-cn1.pexipdemo.com [sin-cn1.pexipdemo.com], us-cn1.pexipdemo.com [us-cn1.pexipdemo.com], us-cn2.pexipdemo.com [us-cn2.pexipdemo.com], us-cn3.pexipdemo.com [us-cn3.pexipdemo.com], us-cn4.pexipdemo.com [us-cn4.pexipdemo.com]

```

vs

```
TLS Certificates
================
CN=*.pexipdemo.com
 -> Issuer: CN=R12,O=Let's Encrypt,C=US (Validates: True)
    Expiry: 2026-07-02 09:08:38+00:00
 Signature: sha256WithRSAEncryption
      SANs: DNS:*.pexipdemo.com, DNS:pexipdemo.com
       EKU: serverAuth
 => aus-cn1.pexipdemo.com [aus-cn1.pexipdemo.com], no-cn1.pexipdemo.com [no-cn1.pexipdemo.com], no-cn2.pexipdemo.com [no-cn2.pexipdemo.com], no-cn3.pexipdemo.com [no-cn3.pexipdemo.com], no-cn4.pexipdemo.com [no-cn4.pexipdemo.com], no-cn5.pexipdemo.com [no-cn5.pexipdemo.com], no-cn6.pexipdemo.com [no-cn6.pexipdemo.com], sin-cn1.pexipdemo.com [sin-cn1.pexipdemo.com], us-cn1.pexipdemo.com [us-cn1.pexipdemo.com], us-cn2.pexipdemo.com [us-cn2.pexipdemo.com], us-cn3.pexipdemo.com [us-cn3.pexipdemo.com], us-cn4.pexipdemo.com [us-cn4.pexipdemo.com]

CN=pexipdemo.com
 -> Issuer: CN=pexuk-DC1-CA,DC=pexuk,DC=local (Validates: True)
    Expiry: 2026-05-22 06:41:41+00:00
 Signature: sha256WithRSAEncryption
      SANs: DNS:pexipdemo.com, DNS:no-cn1.pexipdemo.com, DNS:no-cn2.pexipdemo.com, DNS:no-cn3.pexipdemo.com, DNS:sip.pexipdemo.com, DNS:no-sip.pexipdemo.com
       EKU: serverAuth, clientAuth
 => no-cn1.pexipdemo.com [no-cn1.pexipdemo.com], no-cn2.pexipdemo.com [no-cn2.pexipdemo.com], no-cn3.pexipdemo.com [no-cn3.pexipdemo.com]
```