### PR TITLE
exit silently if no log files are found

### DIFF
--- a/connectivity.py
+++ b/connectivity.py
@@ -76,6 +76,8 @@ def main():
 
     try:
         log_files = sorted(glob.glob(os.path.join(rootdir, 'var/log/*administrator.log*')), key=os.path.getmtime)
+        if not log_files:
+            sys.exit(2)
     except OSError as err:
         print(err)
         sys.exit(2)


### PR DESCRIPTION
Fix the issue when no administrator logs are present the process hanging.

Can occur when time-based snapshots are used.