### PR TITLE
confhistory: add backplane support

### DIFF
--- a/confhistory.py
+++ b/confhistory.py
@@ -15,11 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 from datetime import datetime
 import itertools
 import os
 import sqlite3
-import sys
 
 import locale
 try:
@@ -46,6 +46,29 @@ def dict_factory(cursor, row):
     for idx, col in enumerate(cursor.description):
         d[col[0]] = row[idx]
     return d
+
+
+def parse_args(argv=None):
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description='Extract conference history database into text format')
+    parser.add_argument('conf_or_rootdir', nargs='?', help='Conference name/uuid to search for, or root directory')
+    parser.add_argument('rootdir_pos', nargs='?', help='Root directory when conference name/uuid is provided')
+    parser.add_argument('--show-backplanes', action='store_true', help='Show backplane information')
+    return parser.parse_args(argv)
+
+
+def resolve_inputs(args):
+    """Resolve rootdir and optional conference filter from parsed args."""
+    if args.rootdir_pos:
+        return args.rootdir_pos, args.conf_or_rootdir
+
+    if args.conf_or_rootdir:
+        if os.path.isdir(args.conf_or_rootdir):
+            return args.conf_or_rootdir, None
+        return os.getcwd(), args.conf_or_rootdir
+
+    return os.getcwd(), None
+
 
 class ConfHistory:
     def __init__(self, rootdir):
@@ -75,10 +98,10 @@ class ConfHistory:
     def backplanes(self, c_uuid=None):
         backplanes = {}
         cur = self.history.cursor()
-        cur.execute('SELECT id, type, start_time, end_time, duration, media_node, remote_media_node, proxy_node from conferencinghistory_backplane WHERE conference_id=?', (c_uuid,))
-        headers = ['id', 'type', 'start_time', 'end_time', 'duration']
-        data = [headers]
+        cur.execute('SELECT id, type, media_node, remote_media_node, proxy_node, start_time, end_time, duration FROM conferencinghistory_backplane WHERE conference_id=?', (c_uuid,))
         rows = cur.fetchall()
+        headers = ['id', 'type', 'media_node', 'remote_media_node', 'proxy_node', 'start_time', 'end_time', 'duration']
+        data = [headers]
         if not rows:
             return
         else:
@@ -86,7 +109,7 @@ class ConfHistory:
             print(len("Backplanes") * "=")
             for row in rows:
                 backplanes[row['id']] = row
-                data.append([row['id'], row['type'], row['start_time'], row['end_time'], row['duration']])
+                data.append([row['id'], row['type'], row['media_node'], row['remote_media_node'], row['proxy_node'] if row['proxy_node'] else 'None', row['start_time'], row['end_time'], row['duration']])
             tabulate(data)
         if rows:
             print()
@@ -113,25 +136,9 @@ class ConfHistory:
                     ])
                 if not rows:
                     continue
-                bp = backplanes.get(backplane_id, {})
                 print(backplane_id)
-                if bp.get('proxy_node'):
-                    print(
-                        'Media Node: ' +
-                        str(bp.get('media_node') or 'None') + ' / Proxy Node: ' +
-                        str(bp.get('proxy_node') or 'None') + ' / Remote Media Node: ' +
-                        str(bp.get('remote_media_node') or 'None')
-                    )
-                else:
-                    print(
-                        'Media Node: ' +
-                        str(bp.get('media_node') or 'None') + ' / Remote Media Node: ' +
-                        str(bp.get('remote_media_node') or 'None')
-                    )
                 tabulate(stats)
                 print()
-
-
 
     def participants(self, c_uuid=None, c_name=None, c_start=None):
         participant_count = {}
@@ -228,7 +235,7 @@ class ConfHistory:
             peak_participants = "Peak participants: %d" % max(participant_count.values())
             print(peak_participants)
 
-    def conferences_history(self, conf):
+    def conferences_history(self, conf, show_backplanes=False):
         cur = self.history.cursor()
         if conf:
             cur.execute('SELECT * from conferencinghistory_conference WHERE name LIKE ? OR id = ? ORDER BY start_time', ('%' + conf + '%', conf))
@@ -243,9 +250,10 @@ class ConfHistory:
             print(times)
             print("-" * len(times))
             self.participants(c_uuid=row['id'])
-            print()
-            self.backplanes(c_uuid=row['id'])
-            print()
+            if show_backplanes:
+                print()
+                self.backplanes(c_uuid=row['id'])
+                print()
 
     def conferences_status(self, conf):
         cur = self.status.cursor()
@@ -264,30 +272,16 @@ class ConfHistory:
             print()
 
 
-def main(rootdir, conf=None):
+def main():
     """Main processing - rootdir is /opt/pexip/share equivalent under which databases lie"""
+    args = parse_args()
+    rootdir, conf = resolve_inputs(args)
+
     dba = ConfHistory(rootdir)
 
-    dba.conferences_history(conf)
+    dba.conferences_history(conf, show_backplanes=args.show_backplanes)
     dba.conferences_status(conf)
 
 
 if __name__ == "__main__":
-    rootdir = os.getcwd()
-    search = None
-    if len(sys.argv) > 2:
-        rootdir = sys.argv[2]
-        search = sys.argv[1]
-    elif len(sys.argv) > 1:
-        if os.path.isdir(sys.argv[1]):
-            rootdir = sys.argv[1]
-        else:
-            search = sys.argv[1]
-    try:
-        if len(sys.argv) > 1 and sys.argv[1].endswith("-help"):
-            print("Usage: confhistory [confname] [dir]")
-            print("confname can be partial name of a conference or a uuid")
-        else:
-            main(rootdir, search)
-    except (IOError, KeyboardInterrupt):
-        pass
+    main()

--- a/confhistory.py
+++ b/confhistory.py
@@ -20,6 +20,7 @@ from datetime import datetime
 import itertools
 import os
 import sqlite3
+import sys
 
 import locale
 try:
@@ -51,38 +52,35 @@ def dict_factory(cursor, row):
 def parse_args(argv=None):
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description='Extract conference history database into text format')
-    parser.add_argument('conf_or_rootdir', nargs='?', help='Conference name/uuid to search for, or root directory')
-    parser.add_argument('rootdir_pos', nargs='?', help='Root directory when conference name/uuid is provided')
+    parser.add_argument('rootdir', nargs='?', default=os.getcwd(), help='Root directory under which to find databases (default: current directory)')
+    parser.add_argument('--conf', help='Conference name or uuid to search for')
     parser.add_argument('--show-backplanes', action='store_true', help='Show backplane information')
     return parser.parse_args(argv)
 
 
-def resolve_inputs(args):
-    """Resolve rootdir and optional conference filter from parsed args."""
-    if args.rootdir_pos:
-        return args.rootdir_pos, args.conf_or_rootdir
-
-    if args.conf_or_rootdir:
-        if os.path.isdir(args.conf_or_rootdir):
-            return args.conf_or_rootdir, None
-        return os.getcwd(), args.conf_or_rootdir
-
-    return os.getcwd(), None
-
-
 class ConfHistory:
     def __init__(self, rootdir):
-        self.config = sqlite3.connect(os.path.join(rootdir, 'opt/pexip/share/config/conferencing_configuration.db'))
-        self.config.row_factory = sqlite3.Row
+        def connect_db(db_path, label, row_factory):
+            if not os.path.isfile(db_path):
+                raise FileNotFoundError(f"{label} database not found: {db_path}")
+            try:
+                conn = sqlite3.connect(db_path)
+            except sqlite3.Error as exc:
+                raise RuntimeError(f"Unable to open {label} database: {db_path} ({exc})") from exc
+            conn.row_factory = row_factory
+            return conn
+
+        config_path = os.path.join(rootdir, 'opt/pexip/share/config/conferencing_configuration.db')
+        self.config = connect_db(config_path, 'config', sqlite3.Row)
 
         if os.path.isdir(os.path.join(rootdir, 'opt/pexip/share/status/db')):
-            self.status = sqlite3.connect(os.path.join(rootdir, 'opt/pexip/share/status/db/conferencing_status.db'))
+            status_path = os.path.join(rootdir, 'opt/pexip/share/status/db/conferencing_status.db')
         else:
-            self.status = sqlite3.connect(os.path.join(rootdir, 'opt/pexip/share/status/conferencing_status.db'))
-        self.status.row_factory = dict_factory
+            status_path = os.path.join(rootdir, 'opt/pexip/share/status/conferencing_status.db')
+        self.status = connect_db(status_path, 'status', dict_factory)
 
-        self.history = sqlite3.connect(os.path.join(rootdir, 'opt/pexip/share/history/conferencing_history.db'))
-        self.history.row_factory = dict_factory
+        history_path = os.path.join(rootdir, 'opt/pexip/share/history/conferencing_history.db')
+        self.history = connect_db(history_path, 'history', dict_factory)
         self.nodes = {}
         self.locations = {}
         self._get_nodes()
@@ -275,13 +273,16 @@ class ConfHistory:
 def main():
     """Main processing - rootdir is /opt/pexip/share equivalent under which databases lie"""
     args = parse_args()
-    rootdir, conf = resolve_inputs(args)
+    try:
+        dba = ConfHistory(args.rootdir)
+        dba.conferences_history(args.conf, show_backplanes=args.show_backplanes)
+        dba.conferences_status(args.conf)
+    except (FileNotFoundError, RuntimeError, sqlite3.Error) as exc:
+        print(f"Error: {exc}", file=sys.stderr, flush=True)
+        return 1
 
-    dba = ConfHistory(rootdir)
-
-    dba.conferences_history(conf, show_backplanes=args.show_backplanes)
-    dba.conferences_status(conf)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/confhistory.py
+++ b/confhistory.py
@@ -15,12 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import itertools
-import json
-import operator
 import os
-import re
 import sqlite3
 import sys
 
@@ -79,12 +76,12 @@ class ConfHistory:
         participant_count = {}
         cur = self.history.cursor()
         if c_start and c_name:
-            cur.execute('SELECT * from conferencinghistory_participant WHERE conference_id IS NULL AND conference_name="%s" AND start_time > "%s" ORDER BY start_time' % (c_name, c_start))
+            cur.execute('SELECT * from conferencinghistory_participant WHERE conference_id IS NULL AND conference_name=? AND start_time > ? ORDER BY start_time', (c_name, c_start))
             cur2 = self.status.cursor()
-            cur2.execute('SELECT * from conferencingstatus_participant WHERE conference="%s" ORDER BY connect_time' % c_name)
+            cur2.execute('SELECT * from conferencingstatus_participant WHERE conference=? ORDER BY connect_time', (c_name,))
             itercur = itertools.chain(cur, cur2)
         else:
-            cur.execute('SELECT * from conferencinghistory_participant WHERE conference_id="%s" ORDER BY start_time' % c_uuid)
+            cur.execute('SELECT * from conferencinghistory_participant WHERE conference_id=? ORDER BY start_time', (c_uuid,))
             itercur = cur
 
         for row in itercur:
@@ -141,7 +138,7 @@ class ConfHistory:
 
             if start_ts:
                 cur2 = self.history.cursor()
-                cur2.execute('SELECT * from conferencinghistory_participantmediastream WHERE participant_id="%s"' % row['id'])
+                cur2.execute('SELECT * from conferencinghistory_participantmediastream WHERE participant_id=?', (row['id'],))
                 stats = [['', 'tx_codec', 'tx_resolution', 'tx_bitrate', 'tx_packets_sent', 'tx_packets_lost', 'rx_codec', 'rx_resolution', 'rx_bitrate', 'rx_packets_received', 'rx_packets_lost']]
                 for row in cur2:
                     stats.append([row['stream_type'], row['tx_codec'], row['tx_resolution'], row['tx_bitrate'], row['tx_packets_sent'], row['tx_packets_lost'], row['rx_codec'], row['rx_resolution'], row['rx_bitrate'], row['rx_packets_received'], row['rx_packets_lost']])
@@ -156,15 +153,13 @@ class ConfHistory:
                 prev_ts = ts
 
             print("Peak participants: %d" % max(participant_count.values()))
-            
 
     def conferences_history(self, conf):
-        if conf:
-            sql = 'SELECT * from conferencinghistory_conference WHERE name LIKE "%%%s%%" OR id = "%s" ORDER BY start_time' % (conf, conf)
-        else:
-            sql = 'SELECT * FROM conferencinghistory_conference ORDER BY start_time'
         cur = self.history.cursor()
-        cur.execute(sql)
+        if conf:
+            cur.execute('SELECT * from conferencinghistory_conference WHERE name LIKE ? OR id = ? ORDER BY start_time', ('%' + conf + '%', conf))
+        else:
+            cur.execute('SELECT * FROM conferencinghistory_conference ORDER BY start_time')
 
         for row in cur:
             times = "Start: %s / End: %s" % (row['start_time'], row['end_time'])
@@ -176,14 +171,12 @@ class ConfHistory:
             self.participants(c_uuid=row['id'])
             print()
 
-
     def conferences_status(self, conf):
-        if conf:
-            sql = 'SELECT * from conferencingstatus_conference WHERE name LIKE "%%%s%%" OR id = "%s" ORDER BY start_time' % (conf, conf)
-        else:
-            sql = 'SELECT * FROM conferencingstatus_conference ORDER BY start_time'
         cur = self.status.cursor()
-        cur.execute(sql)
+        if conf:
+            cur.execute('SELECT * from conferencingstatus_conference WHERE name LIKE ? OR id = ? ORDER BY start_time', ('%' + conf + '%', conf))
+        else:
+            cur.execute('SELECT * FROM conferencingstatus_conference ORDER BY start_time')
 
         for row in cur:
             times = "Start: %s / STILL RUNNING" % (row['start_time'],)
@@ -193,7 +186,6 @@ class ConfHistory:
             print("-" * len(times))
             self.participants(c_name=row['name'], c_start=row['start_time'])
             print()
-
 
 
 def main(rootdir, conf=None):

--- a/confhistory.py
+++ b/confhistory.py
@@ -73,9 +73,10 @@ class ConfHistory:
             self.locations[row[0]] = row[2]
 
     def backplanes(self, c_uuid=None):
+        backplanes = {}
         cur = self.history.cursor()
-        cur.execute('SELECT id, type from conferencinghistory_backplane WHERE conference_id=?', (c_uuid,))
-        headers = ['id', 'type']
+        cur.execute('SELECT id, type, start_time, end_time, duration, media_node, remote_media_node, proxy_node from conferencinghistory_backplane WHERE conference_id=?', (c_uuid,))
+        headers = ['id', 'type', 'start_time', 'end_time', 'duration']
         data = [headers]
         rows = cur.fetchall()
         if not rows:
@@ -84,7 +85,8 @@ class ConfHistory:
             print("Backplanes")
             print(len("Backplanes") * "=")
             for row in rows:
-                data.append([row['id'], row['type']])
+                backplanes[row['id']] = row
+                data.append([row['id'], row['type'], row['start_time'], row['end_time'], row['duration']])
             tabulate(data)
         if rows:
             print()
@@ -111,7 +113,21 @@ class ConfHistory:
                     ])
                 if not rows:
                     continue
-                print("Backplane ID: %s" % backplane_id)
+                bp = backplanes.get(backplane_id, {})
+                print(backplane_id)
+                if bp.get('proxy_node'):
+                    print(
+                        'Media Node: ' +
+                        str(bp.get('media_node') or 'None') + ' / Proxy Node: ' +
+                        str(bp.get('proxy_node') or 'None') + ' / Remote Media Node: ' +
+                        str(bp.get('remote_media_node') or 'None')
+                    )
+                else:
+                    print(
+                        'Media Node: ' +
+                        str(bp.get('media_node') or 'None') + ' / Remote Media Node: ' +
+                        str(bp.get('remote_media_node') or 'None')
+                    )
                 tabulate(stats)
                 print()
 

--- a/confhistory.py
+++ b/confhistory.py
@@ -72,6 +72,51 @@ class ConfHistory:
             self.nodes[row[0]] = row[1]
             self.locations[row[0]] = row[2]
 
+    def backplanes(self, c_uuid=None):
+        cur = self.history.cursor()
+        cur.execute('SELECT id, type from conferencinghistory_backplane WHERE conference_id=?', (c_uuid,))
+        headers = ['id', 'type']
+        data = [headers]
+        rows = cur.fetchall()
+        if not rows:
+            return
+        else:
+            print("Backplanes")
+            print(len("Backplanes") * "=")
+            for row in rows:
+                data.append([row['id'], row['type']])
+            tabulate(data)
+        if rows:
+            print()
+            for row in rows:
+                cur2 = self.history.cursor()
+                cur2.execute('SELECT backplane_id, stream_type, tx_codec, tx_resolution, tx_bitrate, tx_packets_sent, tx_packets_lost, rx_codec, rx_resolution, rx_bitrate, rx_packets_received, rx_packets_lost from conferencinghistory_backplanemediastream where backplane_id=?', (row['id'],))
+                rows = cur2.fetchall()
+                stats = [['', 'tx_codec', 'tx_resolution', 'tx_bitrate', 'tx_packets_sent', 'tx_packets_lost', 'rx_codec', 'rx_resolution', 'rx_bitrate', 'rx_packets_received', 'rx_packets_lost']]
+                backplane_id = ''
+                for row in rows:
+                    backplane_id = row['backplane_id']
+                    stats.append([
+                        row['stream_type'],
+                        row['tx_codec'],
+                        row['tx_resolution'],
+                        row['tx_bitrate'],
+                        row['tx_packets_sent'],
+                        row['tx_packets_lost'],
+                        row['rx_codec'],
+                        row['rx_resolution'],
+                        row['rx_bitrate'],
+                        row['rx_packets_received'],
+                        row['rx_packets_lost'],
+                    ])
+                if not rows:
+                    continue
+                print("Backplane ID: %s" % backplane_id)
+                tabulate(stats)
+                print()
+
+
+
     def participants(self, c_uuid=None, c_name=None, c_start=None):
         participant_count = {}
         cur = self.history.cursor()
@@ -141,7 +186,19 @@ class ConfHistory:
                 cur2.execute('SELECT * from conferencinghistory_participantmediastream WHERE participant_id=?', (row['id'],))
                 stats = [['', 'tx_codec', 'tx_resolution', 'tx_bitrate', 'tx_packets_sent', 'tx_packets_lost', 'rx_codec', 'rx_resolution', 'rx_bitrate', 'rx_packets_received', 'rx_packets_lost']]
                 for row in cur2:
-                    stats.append([row['stream_type'], row['tx_codec'], row['tx_resolution'], row['tx_bitrate'], row['tx_packets_sent'], row['tx_packets_lost'], row['rx_codec'], row['rx_resolution'], row['rx_bitrate'], row['rx_packets_received'], row['rx_packets_lost']])
+                    stats.append([
+                        row.get('stream_type', ''),
+                        row.get('tx_codec', ''),
+                        row.get('tx_resolution', ''),
+                        row.get('tx_bitrate', ''),
+                        row.get('tx_packets_sent', ''),
+                        row.get('tx_packets_lost', ''),
+                        row.get('rx_codec', ''),
+                        row.get('rx_resolution', ''),
+                        row.get('rx_bitrate', ''),
+                        row.get('rx_packets_received', ''),
+                        row.get('rx_packets_lost', ''),
+                    ])
                 tabulate(stats)
                 print()
 
@@ -152,7 +209,8 @@ class ConfHistory:
                     participant_count[ts] += participant_count[prev_ts]
                 prev_ts = ts
 
-            print("Peak participants: %d" % max(participant_count.values()))
+            peak_participants = "Peak participants: %d" % max(participant_count.values())
+            print(peak_participants)
 
     def conferences_history(self, conf):
         cur = self.history.cursor()
@@ -169,6 +227,8 @@ class ConfHistory:
             print(times)
             print("-" * len(times))
             self.participants(c_uuid=row['id'])
+            print()
+            self.backplanes(c_uuid=row['id'])
             print()
 
     def conferences_status(self, conf):


### PR DESCRIPTION
- Fix `sqlite3.OperationalError` when conf name contained quote
- Adds backplane output after peak participant count where available


```
Peak participants: 3

Backplanes
==========
id                                    type           media_node     remote_media_node  proxy_node  start_time                  end_time                    duration  
3a7c56ed-cc50-4848-95a0-f5c86b5ca3c7  geo-backplane  10.xx.xx.7     10.xx.xx.93        None        2026-05-12 07:15:10.529080  2026-05-12 07:30:49.899475  939       
98471264-9dba-42ad-a48d-8048e6c8d581  geo-backplane  10.xx.xx.93    10.xx.xx.7         None        2026-05-12 07:15:10.552247  2026-05-12 07:30:51.417650  940       

3a7c56ed-cc50-4848-95a0-f5c86b5ca3c7
              tx_codec  tx_resolution  tx_bitrate  tx_packets_sent  tx_packets_lost  rx_codec  rx_resolution  rx_bitrate  rx_packets_received  rx_packets_lost  
audio         Off                      0           0                0                OPUS                     31          45128                1                
audio         OPUS                     39          46959            3                Off                      0           0                    0                
video         Off                      0           0                0                Off                      1628        32357                0                
video         H264_B_0  1280x720       1446        159308           11               Off                      0           0                    0                
video         Off                      0           0                0                H264_B_0  1280x720       459         85312                0                
presentation  Off                      0           0                0                H264_B_0  1536x816       49          6614                 0                

98471264-9dba-42ad-a48d-8048e6c8d581
              tx_codec  tx_resolution  tx_bitrate  tx_packets_sent  tx_packets_lost  rx_codec  rx_resolution  rx_bitrate  rx_packets_received  rx_packets_lost  
audio         OPUS                     31          45202            1                Off                      0           0                    0                
video         Off                      0           0                0                H264_B_0  1280x720       1405        159314               0                
video         H264_B_0  1280x720       485         85412            9                Off                      0           0                    0                
presentation  H264_B_0  1536x816       30          6630             0                Off                      0           0                    0                


===================================================================
```